### PR TITLE
Don't run hooks during dry run

### DIFF
--- a/holland/commands/backup.py
+++ b/holland/commands/backup.py
@@ -70,9 +70,10 @@ class Backup(Command):
 
         runner.register_cb('after-backup', report_low_space)
 
-        runner.register_cb('before-backup', call_hooks)
-        runner.register_cb('after-backup', call_hooks)
-        runner.register_cb('failed-backup', call_hooks)
+        if not opts.dry_run:
+            runner.register_cb('before-backup', call_hooks)
+            runner.register_cb('after-backup', call_hooks)
+            runner.register_cb('failed-backup', call_hooks)
 
         error = 1
         LOG.info("--- Starting %s run ---", opts.dry_run and 'dry' or 'backup')


### PR DESCRIPTION
https://github.com/holland-backup/holland/issues/121

[after|before|failed]-backup-command is executed during a dry run